### PR TITLE
feat: add vllm-bench-serve skill

### DIFF
--- a/skills/vllm-bench-serve/SKILL.md
+++ b/skills/vllm-bench-serve/SKILL.md
@@ -1,0 +1,181 @@
+---
+name: vllm-bench-serve
+description: Benchmark vLLM or OpenAI-compatible serving endpoints using vllm bench serve. Supports multiple datasets (random, sharegpt, sonnet, HF), backends (openai, openai-chat, vllm-pooling, embeddings), throughput/latency testing with request-rate control, and result saving. Use when benchmarking LLM serving performance, measuring TTFT/TPOT, or load testing inference APIs.
+---
+
+# vLLM Bench Serve
+
+Benchmark vLLM or any OpenAI-compatible serving endpoint using the `vllm bench serve` CLI. Measures throughput, latency (TTFT, TPOT), and goodput against configurable request load.
+
+Reference: [vLLM Bench Serve Documentation](https://docs.vllm.ai/en/latest/cli/bench/serve/)
+
+## Prerequisites
+
+- vLLM installed (or any OpenAI-compatible server running)
+- A vLLM server or API endpoint already serving a model
+- Python environment with vLLM for the benchmark client
+
+## Quick Start
+
+**Basic benchmark against local vLLM server (default random dataset, 1000 prompts):**
+
+```bash
+vllm bench serve \
+  --backend openai-chat \
+  --host 127.0.0.1 \
+  --port 8000 \
+  --model Qwen/Qwen2.5-1.5B-Instruct \
+  --endpoint /v1/chat/completions
+```
+
+**Save results to JSON:**
+
+```bash
+vllm bench serve \
+  --backend openai-chat \
+  --host 127.0.0.1 \
+  --port 8000 \
+  --model Qwen/Qwen2.5-1.5B-Instruct \
+  --endpoint /v1/chat/completions \
+  --save-result \
+  --result-dir ./bench-results \
+  --metadata "version=0.6.0" "tp=1"
+```
+
+> **Note:** When using `--backend openai-chat`, you must specify `--endpoint /v1/chat/completions` (default is `/v1/completions`).
+
+## Core Arguments
+
+| Argument | Default | Description |
+|----------|---------|-------------|
+| `--backend` | `openai` | Backend type: `openai`, `openai-chat`, `openai-embeddings`, `vllm`, `vllm-pooling`, `vllm-rerank`, etc. |
+| `--host` | `127.0.0.1` | Server host |
+| `--port` | `8000` | Server port |
+| `--base-url` | - | Alternative: full base URL instead of host:port |
+| `--endpoint` | `/v1/completions` | API endpoint; use `/v1/chat/completions` for openai-chat |
+| `--model` | (from /v1/models) | Model name |
+| `--num-prompts` | `1000` | Number of prompts to process |
+| `--request-rate` | `inf` | Requests per second; `inf` = burst all at once |
+| `--max-concurrency` | - | Max concurrent requests (caps parallelism) |
+| `--num-warmups` | `0` | Warmup requests before measuring |
+
+## Datasets
+
+| `--dataset-name` | Use Case |
+|------------------|----------|
+| `random` | Synthetic random prompts (default) |
+| `sharegpt` | ShareGPT conversation format; requires `--dataset-path` |
+| `sonnet` | Sonnet-style prompts |
+| `hf` | HuggingFace dataset; requires `--dataset-path` (dataset ID) |
+| `custom` / `custom_mm` | Custom dataset; requires `--dataset-path` |
+| `prefix_repetition` | Prefix repetition benchmark |
+| `random-mm` | Random multimodal (images/videos) |
+| `spec_bench` | Spec bench dataset |
+
+**Dataset-specific options (examples):**
+
+```bash
+# Random: control input/output length
+--dataset-name random --random-input-len 1024 --random-output-len 128
+
+# Sonnet defaults: input 550, output 150, prefix 200
+--dataset-name sonnet --sonnet-input-len 550 --sonnet-output-len 150
+
+# HuggingFace dataset
+--dataset-name hf --dataset-path "lmarena-ai/VisionArena-Chat" --hf-split test
+
+# General overrides (map to dataset-specific args)
+--input-len 512 --output-len 256
+```
+
+## Load Control
+
+```bash
+# Fixed request rate (Poisson process)
+--request-rate 10
+
+# More bursty arrivals (gamma distribution, burstiness < 1)
+--request-rate 10 --burstiness 0.5
+
+# Ramp-up from low to high RPS
+--ramp-up-strategy linear --ramp-up-start-rps 1 --ramp-up-end-rps 50
+
+# Limit concurrency (useful for rate-limited APIs)
+--max-concurrency 32
+```
+
+## Results and Metrics
+
+| Argument | Description |
+|----------|-------------|
+| `--save-result` | Save benchmark results to JSON |
+| `--save-detailed` | Include per-request TTFT, TPOT, errors in JSON |
+| `--append-result` | Append to existing result file |
+| `--result-dir` | Directory for result files |
+| `--result-filename` | Custom filename (default: `{label}-{request_rate}qps-{model}-{timestamp}.json`) |
+| `--percentile-metrics` | Metrics for percentiles: `ttft`, `tpot`, `itl`, `e2el` (default: `ttft,tpot,itl`) |
+| `--metric-percentiles` | Percentile values, e.g. `25,50,99` (default: `99`) |
+| `--goodput` | SLO for goodput: `ttft:500 tpot:50` (ms) |
+
+## Sampling Parameters (OpenAI-compatible backends)
+
+```bash
+--temperature 0.7 --top-p 0.95 --top-k 50
+--frequency-penalty 0 --presence-penalty 0 --repetition-penalty 1.0
+```
+
+## Common Workflows
+
+**1. Throughput test with random dataset (burst):**
+
+```bash
+vllm bench serve --backend openai-chat --host 127.0.0.1 --port 8000 \
+  --model Qwen/Qwen2.5-1.5B-Instruct \
+  --endpoint /v1/chat/completions \
+  --dataset-name random \
+  --num-prompts 500 --random-input-len 512 --random-output-len 128
+```
+
+**2. Latency test with fixed QPS:**
+
+```bash
+vllm bench serve --backend openai-chat --host 127.0.0.1 --port 8000 \
+  --model Qwen/Qwen2.5-1.5B-Instruct \
+  --endpoint /v1/chat/completions \
+  --request-rate 5 --num-prompts 200 \
+  --save-result --percentile-metrics ttft,tpot --metric-percentiles 50,99
+```
+
+**3. Benchmark against remote API (base-url):**
+
+```bash
+vllm bench serve --backend openai-chat \
+  --base-url "https://api.example.com/v1" \
+  --model my-model \
+  --header "Authorization=Bearer $API_KEY"
+```
+
+**4. Run inside Docker (when vLLM client not on host):**
+
+```bash
+docker exec <container-name> vllm bench serve \
+  --backend openai-chat --host 127.0.0.1 --port 8000 \
+  --model Qwen/Qwen2.5-1.5B-Instruct \
+  --endpoint /v1/chat/completions \
+  --dataset-name random --num-prompts 100
+```
+
+## Troubleshooting
+
+- **Connection refused**: Ensure the server is running and `--host`/`--port` or `--base-url` are correct.
+- **Model not found**: Pass `--model` explicitly or ensure `/v1/models` returns the model.
+- **URL must end with chat/completions**: Use `--endpoint /v1/chat/completions` when `--backend openai-chat`.
+- **Rate limit / 429**: Reduce `--request-rate` or `--max-concurrency`.
+- **Ready check**: Use `--ready-check-timeout-sec 60` to wait for the endpoint before benchmarking.
+- **SSL**: Use `--insecure` for self-signed certificates.
+
+## Notes
+
+- For embeddings/rerank benchmarks, use `--backend openai-embeddings`, `vllm-pooling`, or `vllm-rerank`.
+- `--profile` requires `--profiler-config` on the server for vLLM profiling.
+- Goodput SLOs are useful for SLA-style analysis; see [DistServe paper](https://arxiv.org/pdf/2401.09670) for details.


### PR DESCRIPTION
Add vllm-bench-serve skill for benchmarking vLLM or OpenAI-compatible serving endpoints.

- Supports multiple datasets (random, sharegpt, sonnet, HF)
- Supports backends: openai, openai-chat, vllm-pooling, embeddings
- Throughput/latency testing with request-rate control
- Result saving for TTFT/TPOT metrics

# test with cursor

---

**User**

bench vllm serve in container vllm-qwen by port 8000 with random dataset

---

**Cursor**


Running the vLLM benchmark in the `vllm-qwen` container on port 8000 with the random dataset:

```
docker exec vllm-qwen vllm bench serve \
  --backend openai-chat \
  --host 127.0.0.1 \
  --port 8000 \
  --endpoint /v1/chat/completions \
  --dataset-name random \
  --num-prompts 1000

INFO 02-26 11:54:39 [__init__.py:43] Available plugins for group vllm.platform_plugins:
INFO 02-26 11:54:39 [__init__.py:45] - ascend -> vllm_ascend:register
INFO 02-26 11:54:39 [__init__.py:48] All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
INFO 02-26 11:54:39 [__init__.py:217] Platform plugin ascend is activated
INFO 02-26 11:54:46 [__init__.py:108] Registered model loader `<class 'vllm_ascend.model_loader.netloader.netloader.ModelNetLoaderElastic'>` with load format `netloader`
Namespace(subparser='bench', bench_type='serve', dispatch_function=<function BenchmarkServingSubcommand.cmd at 0xffff0f73e200>, seed=0, num_prompts=1000, dataset_name='random', no_stream=False, dataset_path=None, no_oversample=False, skip_chat_template=False, disable_shuffle=False, custom_output_len=256, spec_bench_output_len=256, spec_bench_category=None, sonnet_input_len=550, sonnet_output_len=150, sonnet_prefix_len=200, sharegpt_output_len=None, blazedit_min_distance=0.0, blazedit_max_distance=1.0, random_input_len=1024, random_output_len=128, random_range_ratio=0.0, random_prefix_len=0, random_batch_size=1, no_reranker=False, random_mm_base_items_per_request=1, random_mm_num_mm_items_range_ratio=0.0, random_mm_limit_mm_per_prompt={'image': 255, 'video': 1}, random_mm_bucket_config={(256, 256, 1): 0.5, (720, 1280, 1): 0.5, (720, 1280, 16): 0.0}, hf_subset=None, hf_split=None, hf_name=None, hf_output_len=None, prefix_repetition_prefix_len=256, prefix_repetition_suffix_len=256, prefix_repetition_num_prefixes=10, prefix_repetition_output_len=128, label=None, backend='openai-chat', base_url=None, host='127.0.0.1', port=8000, endpoint='/v1/chat/completions', header=None, max_concurrency=None, model=None, input_len=None, output_len=None, tokenizer=None, tokenizer_mode='auto', use_beam_search=False, logprobs=None, request_rate=inf, burstiness=1.0, trust_remote_code=False, disable_tqdm=False, num_warmups=0, profile=False, save_result=False, save_detailed=False, append_result=False, metadata=None, result_dir=None, result_filename=None, ignore_eos=False, percentile_metrics=None, metric_percentiles='99', goodput=None, request_id_prefix='bench-f8201ccf-', top_p=None, top_k=None, min_p=None, temperature=None, frequency_penalty=None, presence_penalty=None, repetition_penalty=None, served_model_name=None, lora_modules=None, ramp_up_strategy=None, ramp_up_start_rps=None, ramp_up_end_rps=None, ready_check_timeout_sec=0, extra_body=None)
Model not specified, fetching first model from server...
First model name: Qwen/Qwen2.5-1.5B-Instruct, first model id: Qwen/Qwen2.5-1.5B-Instruct
Downloading Model from https://www.modelscope.cn to directory: /root/.cache/modelscope/hub/models/Qwen/Qwen2.5-1.5B-Instruct
INFO 02-26 11:55:00 [datasets.py:612] Sampling input_len from [1024, 1024] and output_len from [128, 128]
Starting initial single prompt test run...
Skipping endpoint ready check.
Starting main benchmark run...
Traffic request rate: inf
Burstiness factor: 1.0 (Poisson process)
Maximum request concurrency: None
tip: install termplotlib and gnuplot to plot the metrics
============ Serving Benchmark Result ============
Successful requests:                     1000      
Failed requests:                         0         
Benchmark duration (s):                  37.36     
Total input tokens:                      1024000   
Total generated tokens:                  128000    
Request throughput (req/s):              26.77     
Output token throughput (tok/s):         3426.19   
Peak output token throughput (tok/s):    5120.00   
Peak concurrent requests:                1000.00   
Total token throughput (tok/s):          30835.73  
---------------Time to First Token----------------
Mean TTFT (ms):                          15587.62  
Median TTFT (ms):                        11452.09  
P99 TTFT (ms):                           32377.55  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          54.58     
Median TPOT (ms):                        54.66     
P99 TPOT (ms):                           62.34     
---------------Inter-token Latency----------------
Mean ITL (ms):                           54.18     
Median ITL (ms):                         54.16     
P99 ITL (ms):                            76.40     
==================================================
2026-02-26 11:54:59,592 - modelscope - INFO - Target directory already exists, skipping creation.
100%|██████████| 1000/1000 [00:37<00:00, 26.77it/s]
sys:1: DeprecationWarning: builtin type swigvarlink has no __module__ attribute


```



Benchmark finished. Summary:

## vLLM Serve Benchmark (vllm-qwen, port 8000, random dataset)

| Metric | Value |
|--------|-------|
| **Model** | Qwen/Qwen2.5-1.5B-Instruct |
| **Successful requests** | 1000 |
| **Failed requests** | 0 |
| **Benchmark duration** | 37.36 s |

### Throughput

- **Request throughput** 26.77 req/s  
- **Output token throughput** 3,426.19 tok/s  
- **Peak output token throughput** 5,120 tok/s  
- **Total token throughput** 30,835.73 tok/s  

### Latency

- **Mean TTFT** 15,587.62 ms  
- **Median TTFT** 11,452.09 ms  
- **P99 TTFT** 32,377.55 ms  
- **Mean TPOT** 54.58 ms  
- **Median TPOT** 54.66 ms  
- **P99 TPOT** 62.34 ms  

### Dataset

- Random dataset with 1,000 prompts  
- Input length 1024 tokens, output length 128 tokens  

To save results next time, add `--save-result --result-dir ./bench-results`.
